### PR TITLE
Fix string sorting with localeCompare

### DIFF
--- a/index.html
+++ b/index.html
@@ -1006,11 +1006,16 @@
           const isNumber = !isNaN(parseFloat(aVal.replace(/[%+()]/g,"")));
           if (isDate) {
             aVal = new Date(aVal); bVal = new Date(bVal);
+            return asc ? aVal - bVal : bVal - aVal;
           } else if (isNumber) {
             aVal = parseFloat(aVal.replace(/[%+()]/g,""));
             bVal = parseFloat(bVal.replace(/[%+()]/g,""));
+            return asc ? aVal - bVal : bVal - aVal;
+          } else {
+            aVal = aVal.toLowerCase();
+            bVal = bVal.toLowerCase();
+            return asc ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal);
           }
-          return asc ? (aVal - bVal) : (bVal - aVal);
         });
         table.querySelectorAll("th").forEach(th => th.classList.remove("asc","desc"));
         header.classList.add(asc?"asc":"desc");

--- a/index.template.html
+++ b/index.template.html
@@ -111,11 +111,16 @@
           const isNumber = !isNaN(parseFloat(aVal.replace(/[%+()]/g,"")));
           if (isDate) {
             aVal = new Date(aVal); bVal = new Date(bVal);
+            return asc ? aVal - bVal : bVal - aVal;
           } else if (isNumber) {
             aVal = parseFloat(aVal.replace(/[%+()]/g,""));
             bVal = parseFloat(bVal.replace(/[%+()]/g,""));
+            return asc ? aVal - bVal : bVal - aVal;
+          } else {
+            aVal = aVal.toLowerCase();
+            bVal = bVal.toLowerCase();
+            return asc ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal);
           }
-          return asc ? (aVal - bVal) : (bVal - aVal);
         });
         table.querySelectorAll("th").forEach(th => th.classList.remove("asc","desc"));
         header.classList.add(asc?"asc":"desc");


### PR DESCRIPTION
## Summary
- update sorting logic in `index.template.html` and `index.html` to use `localeCompare` for text columns

## Testing
- `npm start` *(fails: Cannot find module 'luxon')*

------
https://chatgpt.com/codex/tasks/task_e_6877bfb942008331bc37c9dfad0097ed