### PR TITLE
Add simple localeCompare sort test

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
     "name": "faceit-elo-updater",
     "version": "1.0.0",
     "scripts": {
-      "start": "node fetch-elos.js"
+      "start": "node fetch-elos.js",
+      "test": "node test/sort.test.js"
     },
     "dependencies": {
       "puppeteer": "^24.6.1",

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -1,0 +1,21 @@
+const assert = require('assert');
+
+function sortStrings(arr, asc = true) {
+  const copy = arr.slice();
+  copy.sort((a, b) => {
+    let aVal = a.toLowerCase();
+    let bVal = b.toLowerCase();
+    return asc ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal);
+  });
+  return copy;
+}
+
+// Ascending sort
+let result = sortStrings(['banana', 'Apple', 'cherry']);
+assert.deepStrictEqual(result, ['Apple', 'banana', 'cherry'], 'ascending sort failed');
+
+// Descending sort
+result = sortStrings(['banana', 'Apple', 'cherry'], false);
+assert.deepStrictEqual(result, ['cherry', 'banana', 'Apple'], 'descending sort failed');
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- add a minimal Node.js test verifying the string sorting logic using `localeCompare`
- wire the test into the `npm test` script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877c05ead588331b7b244aefb0c43c2