### PR TITLE
Fix search clearing bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -1039,7 +1039,14 @@
         const show = name.includes(q);
         row.classList.toggle('hidden', !show);
         const detailRow = document.querySelector(`tr.details-row[data-player-id='${row.dataset.playerId}']`);
-        if (detailRow) detailRow.classList.toggle('hidden', !show);
+        if (detailRow && !show) {
+          detailRow.classList.add('hidden');
+          const btn = row.querySelector('.toggle-details');
+          if (btn) {
+            btn.textContent = '▸';
+            btn.setAttribute('aria-expanded', 'false');
+          }
+        }
       });
     });
 </script>

--- a/index.template.html
+++ b/index.template.html
@@ -144,7 +144,14 @@
         const show = name.includes(q);
         row.classList.toggle('hidden', !show);
         const detailRow = document.querySelector(`tr.details-row[data-player-id='${row.dataset.playerId}']`);
-        if (detailRow) detailRow.classList.toggle('hidden', !show);
+        if (detailRow && !show) {
+          detailRow.classList.add('hidden');
+          const btn = row.querySelector('.toggle-details');
+          if (btn) {
+            btn.textContent = '▸';
+            btn.setAttribute('aria-expanded', 'false');
+          }
+        }
       });
     });
 </script>


### PR DESCRIPTION
## Summary
- keep stats collapsed when search filter clears

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877f3bc0ca48331aa01c2453ef32f32